### PR TITLE
[GA] Remove tertiary

### DIFF
--- a/configs/taco/GA.yaml
+++ b/configs/taco/GA.yaml
@@ -6,7 +6,3 @@ links:
 
 - name: secondary
   url: https://www.arcgis.com/apps/opsdashboard/index.html#/e40c39564f724af7bfe8fd5d88deadb6
-
-- name: tertiary
-  url: https://augustagis.maps.arcgis.com/apps/opsdashboard/index.html#/4eec20925b6b4f338368df0ffcba472d
-


### PR DESCRIPTION
Getting rid of GA tertiary screenshot, it never captured any data points and now just shows an arcgis login page, I don't think GA uses it anymore.