### PR TITLE
[PR] adding covid statistics site

### DIFF
--- a/configs/taco/PR.yaml
+++ b/configs/taco/PR.yaml
@@ -48,3 +48,6 @@ links:
     await page.waitForDelay(5000);
     page.done();
   message: click button twice for PR probable deaths ("Probables")
+
+- name: pr_statistics_site
+  url: https://covid19datos.salud.gov.pr


### PR DESCRIPTION
The normal dash and arcgis stores are behind a login now (hopefully just temporarily). This looks like a full dash though, so they may be moving to this one.