### PR TITLE
Fix CDC breakthrough cases page screenshot

### DIFF
--- a/configs/variants/CDC.yaml
+++ b/configs/variants/CDC.yaml
@@ -1,5 +1,0 @@
-state: CDC
-
-links:
-- name: primary
-  url: https://www.cdc.gov/vaccines/covid-19/health-departments/breakthrough-cases.html

--- a/configs/variants/US.yaml
+++ b/configs/variants/US.yaml
@@ -9,3 +9,6 @@ links:
 
 - name: global_map
   url: https://covid.cdc.gov/covid-data-tracker/#global-variant-report-map
+  
+- name: breakthrough_cases
+  url: https://www.cdc.gov/vaccines/covid-19/health-departments/breakthrough-cases.html


### PR DESCRIPTION
Move breakthrough cases from CDC.yaml (which hasn't been running) to US.yaml so we can capture breakthrough cases. 